### PR TITLE
Fix for CMS tree on sitemap

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -63,16 +63,8 @@ class SitemapControllerCore extends FrontController
      */
     protected function getPagesLinks()
     {
-        $links = array();
-
         $cms = CMSCategory::getRecurseCategory($this->context->language->id, 1, 1, 1);
-        foreach ($cms['cms'] as $p) {
-            $links[] = array(
-                'id' => 'cms-page-' . $p['id_cms'],
-                'label' => $p['meta_title'],
-                'url' => $this->context->link->getCMSLink(new CMS($p['id_cms'])),
-            );
-        }
+        $links = $this->getCmsTree($cms);
 
         $links[] = array(
             'id' => 'stores-page',
@@ -91,6 +83,35 @@ class SitemapControllerCore extends FrontController
             'label' => $this->trans('Sitemap', array(), 'Shop.Theme'),
             'url' => $this->context->link->getPageLink('sitemap'),
         );
+
+        return $links;
+    }
+    
+    /**
+     * @return array
+     */
+    protected function getCmsTree($cms)
+    {
+        $links = array();
+
+        foreach ($cms['cms'] as $p) {
+            $links[] = array(
+                'id' => 'cms-page-' . $p['id_cms'],
+                'label' => $p['meta_title'],
+                'url' => $p['link'],
+            );
+        }
+
+        if (isset($cms['children'])) {
+            foreach ($cms['children'] as $c) {
+                $links[] = array(
+                'id' => 'cms-category-' . $c['id_cms_category'],
+                'label' => $c['name'],
+                'url' => $c['link'],
+                'children' => $this->getCmsTree($c),
+            );
+            }
+        }
 
         return $links;
     }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.1.x
| Description?  | On sitemap there was only first level of cms pages. Also removed unnecesary New cms page class creation for getting a link since links is already provided by CMSCategory::getRecurseCategor.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | /no
| Fixed ticket? | 
| How to test?  | In backoffice create some cms categories and put some cms pages inside them, Then go to sitemap page in frontoffice,

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
